### PR TITLE
Fixed the link to magic constants

### DIFF
--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -680,7 +680,7 @@
     </varlistentry>
    </variablelist>
    <para>
-    See also: <link linkend="language.constants.predefined">Magic
+    See also: <link linkend="language.constants.magic">Magic
     constants</link>.
    </para>
  </sect2>


### PR DESCRIPTION
Page https://www.php.net/manual/en/reserved.constants.php contains incorrect link to magic constants (https://www.php.net/manual/en/language.constants.predefined.php) while the correct one is https://www.php.net/manual/en/language.constants.magic.php